### PR TITLE
Add Railway deployment support for multiplayer hosting

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,7 +38,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build site
-        run: pnpm build
+        run: pnpm --filter @neon/web build:pages
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -24,18 +24,17 @@ It started as a quick experiment in what a simple prompt to a coding agent could
 
 - GitHub Pages: `https://paulatkins88.github.io/neon-doom-pit/`
 
-The Pages build deploys automatically from `main` via GitHub Actions.
+GitHub Pages remains a static-only client host. The multiplayer build now targets a full-stack host so the authoritative room server can run alongside the browser app.
 
 ## Scripts
 
 - `pnpm dev`: run the local development server
 - `pnpm dev:server`: run the authoritative multiplayer room server
-- `pnpm build`: production build and main verification command
+- `pnpm build`: build the web client and verify the server production compile
 - `pnpm preview`: preview the production build locally
+- `pnpm start`: start the app server that serves the built web client and WebSocket endpoint on one port
 
-For multiplayer backend changes, also run:
-
-- `pnpm --filter @neon/server build`
+For multiplayer backend changes, `pnpm build` now also verifies the server bundle.
 
 ## Gameplay Summary
 
@@ -177,6 +176,57 @@ To exercise the co-op flow locally:
 5. Use reconnect after closing one tab to verify the grace-window flow
 
 The browser client targets `ws://localhost:2567` by default. Override the port with `VITE_MULTIPLAYER_SERVER_PORT` if needed.
+
+For production, prefer `VITE_MULTIPLAYER_SERVER_URL` when the socket server lives on a different origin. If the browser app and multiplayer server share the same host and port, the client reuses `window.location.host` automatically.
+
+## Railway Deployment
+
+Issue `#21` is addressed with a single-service deployment shape that fits Railway cleanly.
+
+### Recommended Topology
+
+- one Railway web service
+- `apps/server` runs as the Node process
+- the server serves the built `apps/web/dist` files over HTTP
+- the same public Railway domain handles both browser requests and WebSocket upgrades
+
+This avoids cross-origin WebSocket config, keeps only one public URL, and matches Railway's single exposed `PORT` model.
+
+### Railway Settings
+
+- Root directory: repository root
+- Build command: `pnpm install --frozen-lockfile && pnpm build`
+- Start command: `pnpm start`
+
+Railway provides `PORT` automatically. No custom port env var is required for the default single-service setup.
+
+### Optional Environment Variables
+
+- `VITE_MULTIPLAYER_SERVER_URL`
+  - only set this if the browser client should connect to a different WebSocket origin
+- `VITE_MULTIPLAYER_SERVER_PORT`
+  - local/dev override when the server is not on the browser origin
+
+### Health Check
+
+- path: `/health`
+- expected response: `200` with `{"ok":true}`
+
+### Smoke Checklist
+
+After the first Railway deploy, verify:
+
+1. The homepage loads from the Railway domain.
+2. Pointer lock still works after entering the game.
+3. Create room succeeds.
+4. Join room succeeds from a second browser/tab.
+5. Start run succeeds and both players receive live updates.
+6. Reconnect works within the grace window after closing a tab.
+7. Expired reconnect/session flows show the expected failure UI.
+
+### GitHub Pages Status
+
+GitHub Pages should be treated as static-only. It is no longer the authoritative multiplayer deployment target.
 
 ## Multiplayer QA Matrix
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.build.json",
+    "start": "tsx src/index.ts"
   },
   "dependencies": {
     "@neon/shared": "workspace:*",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@neon/shared": "workspace:*",
+    "tsx": "^4.20.6",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -1,12 +1,35 @@
+import { createReadStream, existsSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { dirname, extname, join, normalize } from 'node:path';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { WebSocketServer } from 'ws';
 import { MATCH_TICK_MS, MATCH_TICK_SECONDS, PORT } from './config';
 import { RoomDirectory } from './rooms/RoomDirectory';
 import { ConnectionRegistry } from './transport/ConnectionRegistry';
 import { WsGateway } from './transport/wsGateway';
 
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const WEB_DIST_DIR = join(SERVER_DIR, '../../web/dist');
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
 export interface MultiplayerServer {
   readonly rooms: RoomDirectory;
   readonly socketServer: WebSocketServer;
+  readonly httpServer: ReturnType<typeof createServer>;
   close(): Promise<void>;
 }
 
@@ -14,7 +37,18 @@ export function bootstrapServer(port = PORT): MultiplayerServer {
   const rooms = new RoomDirectory();
   const connections = new ConnectionRegistry();
   const gateway = new WsGateway(rooms, connections);
-  const socketServer = new WebSocketServer({ port });
+  const httpServer = createServer((request, response) => {
+    void handleHttpRequest(request, response);
+  });
+  const socketServer = new WebSocketServer({ noServer: true });
+
+  httpServer.on('upgrade', (request, socket, head) => {
+    socketServer.handleUpgrade(request, socket, head, (webSocket) => {
+      socketServer.emit('connection', webSocket, request);
+    });
+  });
+
+  httpServer.listen(port);
 
   socketServer.on('connection', (socket) => {
     gateway.handleConnection(socket);
@@ -28,15 +62,18 @@ export function bootstrapServer(port = PORT): MultiplayerServer {
 
   interval.unref?.();
 
-  console.info(`[multiplayer] room server listening on ws://localhost:${port}`);
+  console.info(`[multiplayer] app listening on http://localhost:${port}`);
 
   return {
     rooms,
     socketServer,
+    httpServer,
     async close() {
       clearInterval(interval);
+      socketServer.close();
+
       await new Promise<void>((resolve, reject) => {
-        socketServer.close((error) => {
+        httpServer.close((error) => {
           if (error) {
             reject(error);
             return;
@@ -47,4 +84,58 @@ export function bootstrapServer(port = PORT): MultiplayerServer {
       });
     },
   };
+}
+
+async function handleHttpRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const url = new URL(request.url ?? '/', 'http://localhost');
+
+  if (url.pathname === '/health') {
+    response.writeHead(200, { 'content-type': 'application/json; charset=utf-8' });
+    response.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  const filePath = await resolveStaticFilePath(url.pathname);
+
+  if (!filePath) {
+    response.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+    response.end('Not found');
+    return;
+  }
+
+  const extension = extname(filePath).toLowerCase();
+  const contentType = CONTENT_TYPES[extension] ?? 'application/octet-stream';
+
+  response.writeHead(200, { 'content-type': contentType });
+  createReadStream(filePath).pipe(response);
+}
+
+async function resolveStaticFilePath(requestPath: string): Promise<string | null> {
+  if (!existsSync(WEB_DIST_DIR)) {
+    return null;
+  }
+
+  const normalizedPath = normalize(requestPath).replace(/^\/(\.\.(\/|\\|$))+/, '/');
+  const candidatePath = normalizedPath === '/' ? '/index.html' : normalizedPath;
+  const absolutePath = join(WEB_DIST_DIR, candidatePath);
+
+  if (isPathInsideRoot(absolutePath) && await isFile(absolutePath)) {
+    return absolutePath;
+  }
+
+  const indexPath = join(WEB_DIST_DIR, 'index.html');
+  return isPathInsideRoot(indexPath) && await isFile(indexPath) ? indexPath : null;
+}
+
+function isPathInsideRoot(filePath: string): boolean {
+  return filePath.startsWith(WEB_DIST_DIR);
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const fileStat = await stat(filePath);
+    return fileStat.isFile();
+  } catch {
+    return false;
+  }
 }

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -1,6 +1,6 @@
 import { createReadStream, existsSync } from 'node:fs';
 import { stat } from 'node:fs/promises';
-import { dirname, extname, join, normalize } from 'node:path';
+import { dirname, extname, isAbsolute, join, normalize, relative, resolve } from 'node:path';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { WebSocketServer } from 'ws';
@@ -116,11 +116,15 @@ async function resolveStaticFilePath(requestPath: string): Promise<string | null
   }
 
   const normalizedPath = normalize(requestPath).replace(/^\/(\.\.(\/|\\|$))+/, '/');
-  const candidatePath = normalizedPath === '/' ? '/index.html' : normalizedPath;
-  const absolutePath = join(WEB_DIST_DIR, candidatePath);
+  const candidatePath = normalizedPath === '/' ? 'index.html' : normalizedPath.replace(/^\/+/, '');
+  const absolutePath = resolve(WEB_DIST_DIR, candidatePath);
 
   if (isPathInsideRoot(absolutePath) && await isFile(absolutePath)) {
     return absolutePath;
+  }
+
+  if (looksLikeStaticAsset(normalizedPath)) {
+    return null;
   }
 
   const indexPath = join(WEB_DIST_DIR, 'index.html');
@@ -128,7 +132,12 @@ async function resolveStaticFilePath(requestPath: string): Promise<string | null
 }
 
 function isPathInsideRoot(filePath: string): boolean {
-  return filePath.startsWith(WEB_DIST_DIR);
+  const relativePath = relative(WEB_DIST_DIR, filePath);
+  return relativePath !== '' && !relativePath.startsWith('..') && !isAbsolute(relativePath);
+}
+
+function looksLikeStaticAsset(requestPath: string): boolean {
+  return extname(requestPath) !== '';
 }
 
 async function isFile(filePath: string): Promise<boolean> {

--- a/apps/server/tsconfig.build.json
+++ b/apps/server/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "declaration": false,
+    "sourceMap": false
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:pages": "vite build --mode github-pages",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/apps/web/src/network/MultiplayerClient.ts
+++ b/apps/web/src/network/MultiplayerClient.ts
@@ -33,9 +33,21 @@ interface PendingJoinRequest {
 }
 
 function getDefaultServerUrl(): string {
+  const explicitUrl = import.meta.env.VITE_MULTIPLAYER_SERVER_URL;
+
+  if (typeof explicitUrl === 'string' && explicitUrl.length > 0) {
+    return explicitUrl;
+  }
+
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
   const host = window.location.hostname || 'localhost';
   const port = import.meta.env.VITE_MULTIPLAYER_SERVER_PORT ?? '2567';
+  const isDefaultPort = window.location.port.length === 0;
+  const shouldReuseOriginPort = isDefaultPort || window.location.port === port;
+
+  if (shouldReuseOriginPort) {
+    return `${protocol}://${window.location.host}`;
+  }
 
   return `${protocol}://${host}:${port}`;
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,11 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 
-export default defineConfig({
-  base: '/neon-doom-pit/',
+export default defineConfig(({ mode }) => ({
+  base: mode === 'github-pages' ? '/neon-doom-pit/' : '/',
   resolve: {
     alias: {
       '@neon/shared': fileURLToPath(new URL('../../packages/shared/src/index.ts', import.meta.url)),
     },
   },
-})
+}))

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "private": true,
   "scripts": {
     "dev": "pnpm --filter @neon/web dev",
-    "build": "pnpm --filter @neon/web build",
+    "build": "pnpm --filter @neon/web build && pnpm --filter @neon/server build",
     "preview": "pnpm --filter @neon/web preview",
-    "dev:server": "pnpm --filter @neon/server dev"
+    "dev:server": "pnpm --filter @neon/server dev",
+    "start": "pnpm --filter @neon/server start"
   },
   "devDependencies": {
     "tsx": "^4.20.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "start": "pnpm --filter @neon/server start"
   },
   "devDependencies": {
-    "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+buildCommand = "pnpm install --frozen-lockfile && pnpm build"
+
+[deploy]
+startCommand = "pnpm start"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ALWAYS"


### PR DESCRIPTION
## Summary
- switch the multiplayer server to serve the built web client and websocket upgrades on the same port
- add Railway deployment configuration and document the recommended single-service topology for issue #21
- update the web client to reuse the current origin for websocket connections in production while preserving local overrides

## Verification
- pnpm build
- pnpm start